### PR TITLE
Cleanups in the runner

### DIFF
--- a/plugin/contents/code/main.py
+++ b/plugin/contents/code/main.py
@@ -1,22 +1,28 @@
+import subprocess
+
 from PyKDE4 import plasmascript
 from PyKDE4.plasma import Plasma
-from PyKDE4.kdeui import KIcon, KMessageBox
+from PyKDE4.kdeui import KIcon
 from PyKDE4.kdecore import *
 
-import os
 
 class AutoJumpRunner(plasmascript.Runner):
- 
+
     def init(self):
-        # called upon creation to let us run any intialization
-        # tell the user how to use this runner
-		self.addSyntax(Plasma.RunnerSyntax("j :str:", "Jump to :str:"))
- 
+
+        """"Method called when the runner is created. Tells the user how the 
+        runner is used."""
+
+        self.addSyntax(Plasma.RunnerSyntax("j :str:", "Jump to :str:"))
+
     def match(self, context):
-        # called by krunner to let us add actions for the user
+
+        """Method called to determine matches for the runner and subsequent
+        actions."""
+
         if not context.isValid():
             return
- 
+
         q = context.query()
         runInTerminal = True
         # look for our keyword 'j' or 'jo'
@@ -27,38 +33,51 @@ class AutoJumpRunner(plasmascript.Runner):
             runInTerminal = False
         else:
             return
-            
- 
+
         # strip the keyword and leading space
         q = q.trimmed()
- 
-        f = os.popen('autojump --completion %s' % q)
-        result = f.read()
-        lines = result.split('\n')
-        if len(lines) == 0:
+
+        output = subprocess.Popen('autojump --completion %s' % qi, 
+                                  shell=True, stdout=subprocess.PIPE).stdout
+
+        # FIXME: This breaks in case autojump is not installed and the shell
+        # returns some error text
+
+        lines = output.readlines()
+
+        if not lines:
             return
-        
+
         for line in lines:
-            if len(line) > 0:
-                dir = line[line.find('/'):]
-                # now create an action for the user, and send it to krunner
-                m = Plasma.QueryMatch(self.runner)
-                m.setText(dir)
-                m.setType(Plasma.QueryMatch.ExactMatch)
-                m.setIcon(KIcon("dialog-information"))
-                m.setData(runInTerminal)
-                context.addMatch(q, m)
-      
+
+            line = line.rstrip()  # Trim end of line
+
+            if not line:
+                continue
+
+            directory = line[line.find('/'):]
+            # now create an action for the user, and send it to krunner
+            m = Plasma.QueryMatch(self.runner)
+            m.setText(directory)
+            m.setType(Plasma.QueryMatch.ExactMatch)
+            m.setIcon(KIcon("dialog-information"))
+            m.setData(runInTerminal)
+            context.addMatch(q, m)
+
     def run(self, context, match):
-        # called by KRunner when the user selects our action,        
-        runInTerminal = match.data()
-        if runInTerminal.toString() == "false":
+
+        "Method called when the specific action is selected by the user."
+
+        runInTerminal = match.data().toPyObject()
+
+        if runInTerminal:
             KToolInvocation.startServiceByDesktopName("dolphin",match.text())
         else:
             KToolInvocation.invokeTerminal("",match.text())
 
 
-        
 def CreateRunner(parent):
-    # called by krunner, must simply return an instance of the runner object
+
+    "Return an instance of the runner."
+
     return AutoJumpRunner(parent)


### PR DESCRIPTION
A lot of cleanups:
- Don't use the deprecated os.popen(), use subprocess instead
- Docstrings for method and function documentation
- Use idiomatic Python where possible (if list instead of if len(list) >
  0)
- Use PyQt's own toPyObject() method in QVariant rather than a string
  comparison
- Add a FIXME
- Remove stray tabs and mixtures of tabs and spaces
