### PR TITLE
Further little fixes

### DIFF
--- a/plugin/contents/code/main.py
+++ b/plugin/contents/code/main.py
@@ -39,7 +39,7 @@ class AutoJumpRunner(plasmascript.Runner):
 
         #FIXME: Some versions of autojump use --complete instead
 
-        output = subprocess.call(['autojump', '--completion', 'q'],
+        output = subprocess.call(['autojump', '--completion', q],
                                  stdout=subprocess.PIPE)
 
         if output.returncode != 0:

--- a/plugin/contents/code/main.py
+++ b/plugin/contents/code/main.py
@@ -37,13 +37,16 @@ class AutoJumpRunner(plasmascript.Runner):
         # strip the keyword and leading space
         q = q.trimmed()
 
-        output = subprocess.Popen('autojump --completion %s' % q, 
-                                  shell=True, stdout=subprocess.PIPE).stdout
+        #FIXME: Some versions of autojump use --complete instead
 
-        # FIXME: This breaks in case autojump is not installed and the shell
-        # returns some error text
+        output = subprocess.call(['autojump', '--completion', 'q'],
+                                 stdout=subprocess.PIPE)
 
-        lines = output.readlines()
+        if output.returncode != 0:
+            # Error, bail out
+            return
+
+        lines = output.stdout.readlines()
 
         if not lines:
             return


### PR DESCRIPTION
More adjustments:
- check for error code and bail out if not == 0
- use subprocess.call() for easier returncode retrieval
- Don't use shell=True as it's potentially dangerous

Notice that at least my version of autojump wants --complete and not --completion, so I added a FIXME.
